### PR TITLE
Fixed the queries that didn't work with MySQL strict mode

### DIFF
--- a/migrations/4.php
+++ b/migrations/4.php
@@ -21,7 +21,9 @@ class Migration4 extends Base
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_code` DROP FOREIGN KEY `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_code_ibfk_1`;");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_code` CHANGE `secretId` `secret_id` INT(11)  UNSIGNED  NOT NULL;");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_code` ADD FOREIGN KEY (`secret_id`) REFERENCES `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_secret` (`id`) ON DELETE CASCADE;");
+        $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_secret` DROP FOREIGN KEY `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_secret_ibfk_1`;");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_secret` CHANGE `userId` `user_id` INT(11)  UNSIGNED  NOT NULL;");
+        $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_auth_two_factor_device_secret` ADD FOREIGN KEY (`user_id`) REFERENCES `{{NAILS_DB_PREFIX}}user` (`id`) ON DELETE CASCADE");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_email` CHANGE `countSends` `count_sends` INT(11)  UNSIGNED  NOT NULL  DEFAULT '0';");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_email` CHANGE `countSoftBounce` `count_soft_bounce` INT(11)  UNSIGNED  NOT NULL  DEFAULT '0';");
         $this->query("ALTER TABLE `{{NAILS_DB_PREFIX}}user_email` CHANGE `countHardBounce` `count_hard_bounce` INT(11)  UNSIGNED  NOT NULL  DEFAULT '0';");


### PR DESCRIPTION
Queries that were altering a column with a related foreign key were crashing the migration script. Now the migration script removes the foreign key before changing any column's property and after the change it create the foreign key again.